### PR TITLE
add neo4j CSV based ingestion

### DIFF
--- a/graph_data/cli.py
+++ b/graph_data/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import csv
 import json
 import logging
 import sys
@@ -21,6 +21,7 @@ PRETTY_JSON_KWARGS = dict(
     indent=2,
     sort_keys=True)
 
+TMP_DIR = "/tmp"
 logger = structlog.get_logger(__name__)
 fake = Factory.create('en_US')
 
@@ -195,3 +196,94 @@ def neo4j_load_dump_json(ctx):
             neo4j.log_update_query_stats(end_time-start_time, rs)
 
     logger.info('neo4j.json.ingest.done')
+
+
+@cli.command(help="Loads a dump of generated data into neo4j in CSV mode")
+@click.pass_context
+def neo4j_load_dump_csv(ctx):
+    neo4j.ctx = ctx.obj
+    neo4j.create_schema()
+    logger.info('neo4j.csv.ingest.start', folder=ctx.obj.output_dir)
+
+    csv.register_dialect(
+        "gdata", quotechar='"',
+        quoting=csv.QUOTE_NONNUMERIC,
+        doublequote=True,
+    )
+    batch_files = [f for f in listdir(ctx.obj.output_dir)
+                   if isfile(join(ctx.obj.output_dir, f))
+                   and f.endswith('.json')]
+
+    student_ids = []
+    for file in batch_files:
+        with open(join(ctx.obj.output_dir, file), mode='r',
+                  encoding='utf-8') as input:
+            (students_csv_buffer,
+             students_csv_writer,
+             characteristics_csv_buffer,
+             characteristics_csv_writer,
+             friends_csv_buffer,
+             friends_csv_writer) = new_csv_writters()
+            json_data = json.load(input)
+            for item in json_data['data']:
+                students_csv_writer.writerow(
+                    generator.get_student_as_csv_row(item))
+                characteristics_csv_writer.writerows(
+                    generator.get_student_characteristic_rows(item))
+
+                student_ids.append(item['idno'])
+                friends = generator.pick_friends(student_ids)
+                friends = [f for f in friends if f != item['idno']]
+                for friend_idno in friends:
+                    friends_csv_writer.writerow((item['idno'], friend_idno))
+
+            pref = file[:-4]
+            with open(f'{TMP_DIR}/{pref}_students.csv', 'w+') as f:
+                f.write(students_csv_buffer.getvalue())
+            with open(f'{TMP_DIR}/{pref}_characteristics.csv', 'w+') as f:
+                f.write(characteristics_csv_buffer.getvalue())
+            with open(f'{TMP_DIR}/{pref}_friends.csv', 'w+') as f:
+                f.write(friends_csv_buffer.getvalue())
+
+            start_time = datetime.now()
+            logger.info('neo4j.csv.ingest.batch', file=pref)
+            queries = []
+            csv_load_phases = {
+                'students': neo4j.Q_IN_CSV_STUDENTS,
+                'characteristics': neo4j.Q_IN_CSV_CHARACTERISTICS,
+                'friends': neo4j.Q_IN_CSV_FRIENDS
+            }
+            for phase in csv_load_phases.keys():
+                queries.append({
+                    'statement': csv_load_phases[phase].format(
+                        file=f"{TMP_DIR}/{pref}_{phase}.csv"),
+                    'params': {}})
+            rs = neo4j.do_query_update_batch(queries)
+            end_time = datetime.now()
+            neo4j.log_update_query_stats(end_time - start_time, rs)
+
+    logger.info('neo4j.csv.ingest.done')
+
+
+def new_csv_writters():
+    dialect = csv.get_dialect("gdata")
+    students_csv_buffer = io.StringIO()
+    characteristics_csv_buffer = io.StringIO()
+    friends_csv_buffer = io.StringIO()
+    students_csv_writer = csv.writer(
+        students_csv_buffer, dialect=dialect)
+    characteristics_csv_writer = csv.writer(
+        characteristics_csv_buffer, dialect=dialect)
+    friends_csv_writer = csv.writer(
+        friends_csv_buffer, dialect=dialect)
+    # add headers
+    students_csv_writer.writerow(
+        generator.get_student_csv_header())
+    characteristics_csv_writer.writerow(
+        generator.get_student_characteristic_csv_header()
+    )
+    friends_csv_writer.writerow(('idno', 'friend_idno'))
+    return (
+        students_csv_buffer, students_csv_writer,
+        characteristics_csv_buffer, characteristics_csv_writer,
+        friends_csv_buffer, friends_csv_writer)

--- a/graph_data/cli.py
+++ b/graph_data/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import json
+import logging
 import sys
 import io
 import click
@@ -33,7 +34,35 @@ class Namespace():
     pass
 
 
+def init_logger():
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer()
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=logging.INFO,
+    )
+
+    logging.getLogger("requests").setLevel(logging.WARNING)
+
+
 def main():
+    init_logger()
     return cli(obj=Namespace())
 
 

--- a/graph_data/generator.py
+++ b/graph_data/generator.py
@@ -18,6 +18,53 @@ CHARACTERISTIC_TYPES = (
 )
 
 
+def get_student_csv_header():
+    return ('idno',
+            'name',
+            'description',
+            'phone',
+            'country',
+            'city',
+            'address',
+            'university',
+            'faculty',
+            'date_of_birth',
+            'date_enrolled',
+            )
+
+
+def get_student_characteristic_csv_header():
+    return ('idno',
+            'type',
+            'value',
+            )
+
+
+def get_student_as_csv_row(student: dict):
+    return (student['idno'],
+            student['name'],
+            student['description'],
+            student['phone'],
+            student['country'],
+            student['city'],
+            student['address'],
+            student['university'],
+            student['faculty'],
+            student['date_of_birth'],
+            student['date_enrolled'],)
+
+
+def get_student_characteristic_rows(student: dict):
+    result = []
+    for characteristic in student['characteristics']:
+        result.append((
+            student['idno'],
+            characteristic['type'],
+            characteristic['value'],
+        ))
+    return result
+
+
 def generate_student():
     date_of_birth = fake.date_time_between(start_date='-45y', end_date='-22y')
     street_name = fake.street_name()

--- a/graph_data/neo4j.py
+++ b/graph_data/neo4j.py
@@ -50,8 +50,8 @@ Q_IN_CSV_CHARACTERISTICS = """
     LOAD CSV WITH HEADERS FROM 'file://{file}' AS line
     MERGE (s:Student {{idno:line.idno}})
     MERGE (ch:Characteristic {{id:line.type+':'+line.value}})
-    ON CREATE SET ch.type=line.type, ch.value=line.value
-      MERGE (s)-[:characteristic]->(ch)
+      ON CREATE SET ch.type=line.type, ch.value=line.value
+    MERGE (s)-[:characteristic]->(ch)
     """
 
 Q_IN_CSV_FRIENDS = """

--- a/graph_data/neo4j.py
+++ b/graph_data/neo4j.py
@@ -22,7 +22,7 @@ Q_IN_STUDENTS = """
     FOREACH (characteristic in student.characteristics |
       MERGE (ch:Characteristic {id:characteristic.type+':'+characteristic.value})
         ON CREATE SET ch.type=characteristic.type, ch.value=characteristic.value
-      MERGE (s)-[:charasteristic]->(ch)
+      MERGE (s)-[:characteristic]->(ch)
     )
     FOREACH (fr in student.friends |
       MERGE (t:Student {idno:fr})
@@ -44,7 +44,7 @@ def do_query_update(query, params={}):
             'includeStats': True
         }]
     }
-    query_request = json.dumps(query_request).encode('utf-8')
+    query_request = json.dumps(query_request).encode()
     response = requests.post(url, data=query_request)
     raise_for_update_errors(response)
     return response
@@ -69,7 +69,7 @@ def do_query_update_batch(queries):
         'statements': statements
     }
 
-    query_request = json.dumps(query_request).encode('utf-8')
+    query_request = json.dumps(query_request).encode()
     response = requests.post(url, data=query_request)
     raise_for_update_errors(response)
     return response

--- a/graph_data/neo4j.py
+++ b/graph_data/neo4j.py
@@ -30,6 +30,37 @@ Q_IN_STUDENTS = """
     )
     """
 
+Q_IN_CSV_STUDENTS = """
+    LOAD CSV WITH HEADERS FROM 'file://{file}' AS line
+    MERGE (s:Student {{idno:line.idno}})
+    SET 
+        s.name = line.name, 
+        s.description = line.description, 
+        s.phone = line.phone, 
+        s.country = line.country, 
+        s.city = line.city, 
+        s.address = line.address, 
+        s.university = line.university, 
+        s.faculty = line.faculty, 
+        s.date_of_birth = line.date_of_birth, 
+        s.date_enrolled = line.date_enrolled 
+    """
+
+Q_IN_CSV_CHARACTERISTICS = """
+    LOAD CSV WITH HEADERS FROM 'file://{file}' AS line
+    MERGE (s:Student {{idno:line.idno}})
+    MERGE (ch:Characteristic {{id:line.type+':'+line.value}})
+    ON CREATE SET ch.type=line.type, ch.value=line.value
+      MERGE (s)-[:characteristic]->(ch)
+    """
+
+Q_IN_CSV_FRIENDS = """
+    LOAD CSV WITH HEADERS FROM 'file://{file}' AS line
+    MERGE (s:Student {{idno:line.idno}})
+    MERGE (fr:Student {{idno:line.friend_idno}})
+    MERGE (s)-[:friend]->(ch)
+    """
+
 
 def do_query_update(query, params={}):
     """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(here('requirements.txt')) as fp:
 
 setup(
     name='graph-data',
-    version='0.1.0a0',
+    version='0.2.0a0',
     packages=find_packages(),
     install_requires=install_requires,
     entry_points={


### PR DESCRIPTION
add `graph-data neo4j_load_dump_csv` command which is a **`CSV` based ingestion for neo4j**
it takes `json` files generated by `graph-data dump` from an output dir, converts them to `CSV` files then loads them into 
neo4j using `LOAD CSV ...` queries...

_bonus:_ add `logger` configuration and some minor fixes 